### PR TITLE
去掉引起 https 请求报警的链接引入方式

### DIFF
--- a/www/template/default/common/qrcode.html.php
+++ b/www/template/default/common/qrcode.html.php
@@ -12,13 +12,13 @@
           <?php if(!$public->qrcode) continue;?>
           <td>
             <div class='heading'><i class='icon-weixin'>&nbsp;</i> <?php echo $public->name;?></div>
-            <?php echo html::image('javascript:;', "data-src='{$public->qrcode}' width='200' height='200'");?>
+            <?php echo html::image('#', "data-src='{$public->qrcode}' width='200' height='200'");?>
           </td>
           <?php endforeach;?>
           <?php if(extension_loaded('gd')):?>
           <td>
             <div class='heading'><i class='icon-mobile-phone'></i> <?php echo $lang->qrcodeTip;?></div>
-            <?php echo html::image('data:image/png;base64', "width='200' height='200' data-src='" . $this->createLink('misc', 'qrcode') . "'");?>
+            <?php echo html::image('', "width='200' height='200' data-src='" . $this->createLink('misc', 'qrcode') . "'");?>
           </td>
           <?php endif;?>
         </tr>


### PR DESCRIPTION
在使用了 https 方式访问时，如果在 a 超链接中设置的是href="javascript:;"https 会被降级，安全链接将变得不安全
